### PR TITLE
fix: `fix-failed-builds` typo on cookbook `README`

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,7 +17,7 @@ These examples are designed to work with any MCP supported AI agents directly in
 
 ## Examples
 
-- [Fix Failed CircleCI Builds](./examples/get-build-failure-logs)
+- [Fix Failed CircleCI Builds](./examples/fix-failed-builds)
 
 ## Prerequisites
 


### PR DESCRIPTION
# Changes
- fixed: `fix-failed-builds` typo on cookbook `README` - https://github.com/CircleCI-Public/circleci-mcp-cookbook/commit/8595496658825b389254af6bd4ceaa12184f6214